### PR TITLE
remove assertion when ignoring or repeating 0 calls

### DIFF
--- a/src/stub/call.hpp
+++ b/src/stub/call.hpp
@@ -168,7 +168,6 @@ namespace stub
             ///         function calls
             expectation& repeat(uint32_t times)
             {
-                assert(times > 0);
                 assert(m_calls.size() > 0);
 
                 for (uint32_t i = 0; i < times; ++i)
@@ -217,8 +216,6 @@ namespace stub
             ///         function calls
             expectation& ignore(uint32_t calls)
             {
-                assert(calls > 0);
-
                 // We skip the arguments already added
                 uint32_t skip = (uint32_t)m_calls.size();
 

--- a/test/src/test_call.cpp
+++ b/test/src/test_call.cpp
@@ -236,6 +236,35 @@ TEST(call, expect_calls_with_ignore)
                     .with(2,6));
 }
 
+namespace
+{
+    void test_most_recent_call(uint32_t calls)
+    {
+        stub::call<void(uint32_t)> function;
+
+        uint32_t argument;
+        for (uint32_t i; i < calls; ++i)
+        {
+            argument = i;
+            function(argument);
+        }
+
+        EXPECT_TRUE((bool)function.expect_calls()
+                    .ignore(function.calls() - 1)
+                    .with(argument));
+    }
+}
+
+// Check that the most recent call can be checked.
+TEST(call, most_recent_call)
+{
+
+    for (uint32_t calls = 1; calls < 100; ++calls)
+    {
+        test_most_recent_call(calls);
+    }
+}
+
 /// Test that we can use a binary predicate to provide custom
 /// comparisons for types that do not support the default operator==
 struct cup

--- a/test/src/test_call.cpp
+++ b/test/src/test_call.cpp
@@ -242,8 +242,8 @@ namespace
     {
         stub::call<void(uint32_t)> function;
 
-        uint32_t argument;
-        for (uint32_t i; i < calls; ++i)
+        uint32_t argument = 0;
+        for (uint32_t i = 0; i < calls; ++i)
         {
             argument = i;
             function(argument);


### PR DESCRIPTION
I think we've already had this discussion for the fifi library. But I'll try again, as it creates a bit of annoyance for me when i'm writing tests.